### PR TITLE
fixed rogue curly brace when tabbing after an include

### DIFF
--- a/Snippets/include 2.tmSnippet
+++ b/Snippets/include 2.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>{% include '${1:template}' with {
 	${2:key}: ${3:'${4:value}'}
-}} %}
+} %}
 $0</string>
 	<key>name</key>
 	<string>include w/ key/value</string>

--- a/Snippets/include 3.tmSnippet
+++ b/Snippets/include 3.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>{% include '${1:template}' }%}$0</string>
+	<string>{% include '${1:template}' %}$0</string>
 	<key>name</key>
 	<string>include</string>
 	<key>scope</key>

--- a/Snippets/include 4.tmSnippet
+++ b/Snippets/include 4.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>{% include '${1:template}' }%}$0</string>
+	<string>{% include '${1:template}' %}$0</string>
 	<key>name</key>
 	<string>inc</string>
 	<key>scope</key>


### PR DESCRIPTION
Found an extra curly brace appearing when I did `inc` tab